### PR TITLE
IPv6 support

### DIFF
--- a/files/root/usr/sbin/aliddns
+++ b/files/root/usr/sbin/aliddns
@@ -8,23 +8,30 @@ uci_get_by_name() {
 	echo ${ret:=$3}
 }
 
-uci_bool_by_name() {
-	case "$(uci_get_by_name $1 $2)" in
-		1|on|true|yes|enabled) return 0;;
-	esac
-	return 1
-}
-
 intelnetip() {
-	tmp_ip=`curl -sL --connect-timeout 3   ns1.dnspod.net:6666`
+	tmp_ip=`curl -sL --connect-timeout 3   api-ipv4.ip.sb/ip`
 	if [ "Z$tmp_ip" == "Z" ]; then
 		tmp_ip=`curl -sL --connect-timeout 3 members.3322.org/dyndns/getip`
 	fi
 	if [ "Z$tmp_ip" == "Z" ]; then
-		tmp_ip=`curl -sL --connect-timeout 3 14.215.150.17:6666`
+		tmp_ip=`curl -sL --connect-timeout 3 v4.myip.la`
 	fi
 	if [ "Z$tmp_ip" == "Z" ]; then
 		tmp_ip=`curl -sL --connect-timeout 3 whatismyip.akamai.com`
+	fi
+	echo -n $tmp_ip
+}
+
+intelnetip6() {
+	tmp_ip=`curl -sL --connect-timeout 3   ipv6.whatismyip.akamai.com`
+	if [ "Z$tmp_ip" == "Z" ]; then
+		tmp_ip=`curl -sL --connect-timeout 3 speed.neu6.edu.cn/getIP.php`
+	fi
+	if [ "Z$tmp_ip" == "Z" ]; then
+		tmp_ip=`curl -sL --connect-timeout 3 v6.ident.me`
+	fi
+	if [ "Z$tmp_ip" == "Z" ]; then
+		tmp_ip=`curl -sL --connect-timeout 3 api-ipv6.ip.sb/ip`
 	fi
 	echo -n $tmp_ip
 }
@@ -41,6 +48,22 @@ resolve2ip() {
 	fi
 	if [ "Z$tmp_ip" == "Z" ]; then
 		tmp_ip=`curl -sL --connect-timeout 3 "119.29.29.29/d?dn=$domain"`
+	fi
+	echo -n $tmp_ip
+}
+
+resolve2ip6() {
+	# resolve2ip6 domain<string>
+	domain=$1
+	tmp_ip=`nslookup    $domain ns1.alidns.com 2>/dev/null | sed '/^Server/d; /#53$/d' | grep -oE '([0-9A-Fa-f]{0,4}:){2,7}([0-9A-Fa-f]{1,4}$|((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})' | tail -n1`
+	if [ "Z$tmp_ip" == "Z" ]; then
+		tmp_ip=`nslookup $domain ns2.alidns.com  2>/dev/null | sed '/^Server/d; /#53$/d' | grep -oE '([0-9A-Fa-f]{0,4}:){2,7}([0-9A-Fa-f]{1,4}$|((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})' | tail -n1`
+	fi
+	if [ "Z$tmp_ip" == "Z" ]; then
+		tmp_ip=`nslookup $domain 114.114.115.115 2>/dev/null | sed '/^Server/d; /#53$/d' | grep -oE '([0-9A-Fa-f]{0,4}:){2,7}([0-9A-Fa-f]{1,4}$|((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})' | tail -n1`
+	fi
+	if [ "Z$tmp_ip" == "Z" ]; then
+		tmp_ip=`curl -sL --connect-timeout 3 "119.29.29.29/d?dn=$domain&type=AAAA"`
 	fi
 	echo -n $tmp_ip
 }
@@ -65,6 +88,27 @@ check_aliddns() {
 	fi
 }
 
+check_aliddns6() {
+	echo "$DATE WAN6-IP: ${ip6}"
+	if [ "Z$ip6" == "Z" ]; then
+		echo "$DATE ERROR, cant get WAN6-IP..."
+		return 0
+	fi
+	current_ip6=$(resolve2ip6 "$sub_dm.$main_dm")
+	if [ "Z$current_ip6" == "Z" ]; then
+		rrid6='' # NO Resolve IP Means new Record_ID
+	fi
+	echo "$DATE DOMAIN-IP6: ${current_ip6}"
+	if [ "Z$ip6" == "Z$current_ip6" ]; then
+		echo "$DATE IPv6 dont need UPDATE..."
+		return 0
+	else
+		echo "$DATE UPDATING AAAA..."
+		return 1
+	fi
+}
+
+
 urlencode() {
 	# urlencode url<string>
 	out=''
@@ -81,11 +125,16 @@ send_request() {
 	# send_request action<string> args<string>
 	local args="AccessKeyId=$ak_id&Action=$1&Format=json&$2&Version=2015-01-09"
 	local hash=$(urlencode $(echo -n "GET&%2F&$(urlencode $args)" | openssl dgst -sha1 -hmac "$ak_sec&" -binary | openssl base64))
+	#echo "$DATE UPDATE URL IS: http://alidns.aliyuncs.com/?$args&Signature=$hash"
 	curl -sSL --connect-timeout 5 "http://alidns.aliyuncs.com/?$args&Signature=$hash"
 }
 
 get_recordid() {
-	sed 's/RR/\n/g' | sed -n 's/.*RecordId[^0-9]*\([0-9]*\).*/\1\n/p' | sort -ru | sed /^$/d
+	sed -n 's/.*RecordId[^0-9]*\([0-9]*\).*/\1/p'
+}
+get_recordid6() {
+	#sed -n 's/.*RecordId[^0-9]*\([0-9]*\).*/\1/p'
+	/usr/bin/lua /usr/sbin/aliddns.lua $1
 }
 
 query_recordid() {
@@ -100,19 +149,15 @@ add_record() {
 	send_request "AddDomainRecord&DomainName=$main_dm" "RR=$sub_dm&SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp&SignatureVersion=1.0&Timestamp=$timestamp&Type=A&Value=$ip"
 }
 
-del_record() {
-	send_request "DeleteDomainRecord" "RecordId=$1&SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp&SignatureVersion=1.0&Timestamp=$timestamp"
+update_record6() {
+	send_request "UpdateDomainRecord" "RR=$sub_dm&RecordId=$1&SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp6&SignatureVersion=1.0&Timestamp=$timestamp&Type=AAAA&Value=$ip6encoded"
+}
+
+add_record6() {
+	send_request "AddDomainRecord&DomainName=$main_dm" "RR=$sub_dm&SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp6&SignatureVersion=1.0&Timestamp=$timestamp&Type=AAAA&Value=$ip6encoded"
 }
 
 do_ddns_record() {
-	if uci_bool_by_name base clean ; then
-		query_recordid | get_recordid | while read rr; do
-			echo "$DATE Clean record $sub_dm.$main_dm: $rr"
-			del_record $rr >/dev/null
-			timestamp=$(date -u "+%Y-%m-%dT%H%%3A%M%%3A%SZ")
-		done
-		rrid=''
-	fi
 	if [ "Z$rrid" == "Z" ]; then
 		rrid=`query_recordid | get_recordid`
 	fi
@@ -121,6 +166,7 @@ do_ddns_record() {
 		echo "$DATE ADD record $rrid"
 	else
 		update_record $rrid >/dev/null 2>&1
+		#update_record $rrid
 		echo "$DATE UPDATE record $rrid"
 	fi
 	if [ "Z$rrid" == "Z" ]; then
@@ -131,6 +177,29 @@ do_ddns_record() {
 		uci set aliddns.base.record_id=$rrid
 		uci commit aliddns
 		echo "$DATE # UPDATED($ip)"
+	fi
+}
+
+do_ddns_record6() {
+	if [ "Z$rrid6" == "Z" ]; then
+		rrid6=`get_recordid6 $(query_recordid)`
+	fi
+	if [ "Z$rrid6" == "Z" ]; then
+		rrid6=`add_record6 | get_recordid`
+		echo "$DATE ADD record $rrid6"
+	else
+		update_record6 $rrid6 >/dev/null 2>&1
+		#update_record6 $rrid6
+		echo "$DATE UPDATE record $rrid6"
+	fi
+	if [ "Z$rrid6" == "Z" ]; then
+		# failed
+		echo "$DATE # ERROR, Please Check Config/Time"
+	else
+		# save rrid6
+		uci set aliddns.base.record_id6=$rrid6
+		uci commit aliddns
+		echo "$DATE # UPDATED($ip6)"
 	fi
 }
 
@@ -147,18 +216,26 @@ clean_log() {
 ak_id=$(uci_get_by_name   base app_key)
 ak_sec=$(uci_get_by_name  base app_secret)
 rrid=$(uci_get_by_name    base record_id)
+rrid6=$(uci_get_by_name   base record_id6)
 main_dm=$(uci_get_by_name base main_domain)
 sub_dm=$(uci_get_by_name  base sub_domain)
 
 iface=$(uci_get_by_name   base interface)
 if [ "Z$iface" == "Zinternet" -o "Z$iface" == "Z" ]; then
 	ip=$(intelnetip)
+	ip6=$(intelnetip6)
 else
-	ip=$(ubus call network.interface.$iface status | grep '"address"' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
+	ip=$(ubus call network.interface.$iface status | grep '"address"' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+	ip6=$(ubus call network.interface.$iface status | grep '"address"' | grep -oE '([0-9A-Fa-f]{0,4}:){2,7}([0-9A-Fa-f]{1,4}$|((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})')
 fi
+
+ip6encoded=`urlencode $ip6`
 
 DATE=$(date +'%Y-%m-%d %H:%M:%S')
 timestamp=$(date -u "+%Y-%m-%dT%H%%3A%M%%3A%SZ")
 
 clean_log
 check_aliddns || do_ddns_record
+
+timestamp6=$(date -u "+%m-%d-%YT%H%%3A%M%%3A%SZ")
+check_aliddns6 || do_ddns_record6

--- a/files/root/usr/sbin/aliddns
+++ b/files/root/usr/sbin/aliddns
@@ -132,13 +132,13 @@ send_request() {
 get_recordid() {
 	sed -n 's/.*RecordId[^0-9]*\([0-9]*\).*/\1/p'
 }
-get_recordid6() {
-	#sed -n 's/.*RecordId[^0-9]*\([0-9]*\).*/\1/p'
-	/usr/bin/lua /usr/sbin/aliddns.lua $1
-}
 
 query_recordid() {
-	send_request "DescribeSubDomainRecords" "SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp&SignatureVersion=1.0&SubDomain=$sub_dm.$main_dm&Timestamp=$timestamp"
+	send_request "DescribeSubDomainRecords" "SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp&SignatureVersion=1.0&SubDomain=$sub_dm.$main_dm&Timestamp=$timestamp&Type=A"
+}
+
+query_recordid6() {
+	send_request "DescribeSubDomainRecords" "SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp&SignatureVersion=1.0&SubDomain=$sub_dm.$main_dm&Timestamp=$timestamp&Type=AAAA"
 }
 
 update_record() {
@@ -182,7 +182,7 @@ do_ddns_record() {
 
 do_ddns_record6() {
 	if [ "Z$rrid6" == "Z" ]; then
-		rrid6=`get_recordid6 $(query_recordid)`
+		rrid6=`query_recordid6 | get_recordid`
 	fi
 	if [ "Z$rrid6" == "Z" ]; then
 		rrid6=`add_record6 | get_recordid`

--- a/files/root/usr/sbin/aliddns.lua
+++ b/files/root/usr/sbin/aliddns.lua
@@ -1,0 +1,12 @@
+#!/usr/bin/lua
+json=require "luci.jsonc"
+if arg[1] then
+	d=json.parse(arg[1])
+else
+	print("arg1 not exist")
+end
+for k,v in pairs(d.DomainRecords.Record) do
+	if	v.Type=="AAAA" then
+		print(v.Value)
+	end
+end

--- a/files/root/usr/sbin/aliddns.lua
+++ b/files/root/usr/sbin/aliddns.lua
@@ -7,6 +7,6 @@ else
 end
 for k,v in pairs(d.DomainRecords.Record) do
 	if	v.Type=="AAAA" then
-		print(v.Value)
+		print(v.RecordId)
 	end
 end


### PR DESCRIPTION
Added support for IPv6 AAAA record

Note:

I failed to figure out how to do get_recordid() for IPv6 with pure sed -_-! So I created another script, in Lua, to parse the JSON string retrieved from Aliyun DNS server and find the AAAA value.

The Lua script used luci.jsonc, which is included in the official build of OpenWrt 19.07 for my NETGEAR R6100.

If you can do it with sed then plz make it happen which will be very cool